### PR TITLE
Update theme.html

### DIFF
--- a/reference/theme.html
+++ b/reference/theme.html
@@ -530,12 +530,12 @@ inherits from <code>rect</code>)</p></td>
     </tr>
     <tr>
       <th>strip.background.x</th>
-      <td><p>backgronud of horizontal facet labels
+      <td><p>background of horizontal facet labels
 (<code>element_rect</code>; inherits from <code>strip.background</code>)</p></td>
     </tr>
     <tr>
       <th>strip.background.y</th>
-      <td><p>backgronud of vertical facet labels
+      <td><p>background of vertical facet labels
 (<code>element_rect</code>; inherits from <code>strip.background</code>)</p></td>
     </tr>
     <tr>


### PR DESCRIPTION
Hi - I found 2 very minor typos on the reference page
https://ggplot2.tidyverse.org/reference/theme.html

This PR updates these typos from "backgronud" to "background" for  the entries relating to the theme arguments for
strip.background.x  
and 
strip.background.y